### PR TITLE
Upgrading catch to version 1.5.0

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,23 +1,28 @@
 from conans import ConanFile
 import os
+from os import path
 from conans.tools import download, unzip, check_sha256
 from conans import CMake
 
 class ArbitraryName(ConanFile):
     name = "catch"
-    version = "1.3.0"
+    version = "1.5.0"
     branch = "stable"
     license = "Boost"
     generators = "cmake"
     url="http://github.com/TyRoXx/conan-catch"
-    ZIP_FOLDER_NAME = "Catch-1.3.0"
+
+    ZIP_FOLDER_NAME = "Catch-1.5.0"
+    ZIP_URL_NAME = 'V1.5.0.zip'
+    FILE_SHA = '4c0559ef05f9caa08eb2357944135ec3752911627b5908636ce18399a41a12e6'
 
     def source(self):
         zip_name = "catch.zip"
-        download("https://github.com/philsquared/Catch/archive/v1.3.0.zip", zip_name)
-        check_sha256(zip_name, "dd7e7d8f58033bfcd77fe842b749ad6a1ba46e61a3f9dba970181c95fdfe5c5b")
+        download("https://github.com/philsquared/Catch/archive/%s" % self.ZIP_URL_NAME, zip_name)
+        check_sha256(zip_name, self.FILE_SHA)
         unzip(zip_name)
         os.unlink(zip_name)
 
     def package(self):
-        self.copy("*.h*", "include", "%s/include" % self.ZIP_FOLDER_NAME, keep_path=True)
+        self.copy("catch.hpp", "include", path.join(self.ZIP_FOLDER_NAME, 'single_include'))
+        self.copy("catch_with_main.hpp", "include", path.join(self.ZIP_FOLDER_NAME, 'include'))


### PR DESCRIPTION
Changes made:
- Using single_include (instead of copying all include files)
- Adding catch_with_main.hpp to includes
